### PR TITLE
Add atom install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-#Toothpaste
+# Toothpaste
 A custom theme for Sublime Text, Atom and Xcode with flavorful colors that pop and are muted where necessary
 
-##Sublime Text
+## Sublime Text
 ![image](Screen Shot 2016-01-30 at 4.34.21 PM.png)
 ![image](Screen Shot 2016-01-30 at 4.35.40 PM.png)
 
-###Installation:
-####With Package Control
+### Installation:
+#### With Package Control
 1. Run Package Control in Sublime
 2. Search for 'toothpaste' and Install
 3. Go to Preferences > Color Schemes > Toothpaste
 
-####Manually
+#### Manually
 1. Download the theme file
 2. ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/
 3. mkdir toothpaste
@@ -19,43 +19,48 @@ A custom theme for Sublime Text, Atom and Xcode with flavorful colors that pop a
 5. Start Sublime Text
 6. Go to Preferences > Color Schemes > Toothpaste Color Scheme
 
-##Atom
+## Atom
 ![image](toothpaste_atom_screenshot.png)
-###Installation:
-####With Package Control
-*Coming Soon*
+### Installation:
+#### With [Atom Package Manager](https://atom.io/themes/toothpaste)
+1. Navigate to the install section within Atom's settings
+2. Search for 'toothpaste' with the `themes` option selected
+3. Click `install`
+4. Navigate to themes and select `Toothpaste` from the Syntax themes dropdown
 
-####Manually
-*Coming Soon*
+#### Manually (OSX)
+1. Download or clone this repo
+2. Either drag the entire directory or clone this repo directly into the packages directory located at `~/.atom/packages/.
+3. Navigate to the 'Themes' section within Atom's settings panel and choose `Toothpaste` from the Syntax themes dropdown.
 
 *Note*: Toothpaste for atom works best with the One Dark or One Light UI themes. Toothpaste is a syntax theme and is therefore inherited by One Dark/Light UI themes.
 
-##Xcode
+## Xcode
 ![image](Screen Shot 2016-02-05 at 08.33.27.png)
-###Installation:
-####With [Alcatraz](http://alcatraz.io)
+### Installation:
+#### With [Alcatraz](http://alcatraz.io)
 *Coming Soon*
 
-####Manually
+#### Manually
 1. Download the dvtcolortheme file
 2. rsync -av ~/Downloads/toothpaste.dvtcolortheme ~/Library/Developer/Xcode/UserData/FontAndColorThemes/
 3. Start Xcode
 4. Go to Preferences > Fonts & Colors > Toothpaste
 
-##WebStorm
+## WebStorm
 ![image](toothpaste_webstorm_screenshot.png)
-###Installation:
-####Manually
+### Installation:
+#### Manually
 1. Download the theme `.jar` file
 2. Navigate to File > Import Settings and select the JAR file you just downloaded
 
-##Contact
+## Contact
 - See something wrong? Have suggestions? Open up an issue or pull request. I'll be tweaking the theme here & there. <3
 - For any questions or feedback, don't hesistate to reach out via [twitter](http://twitter.com/imcatnoone) or [email](mailto:hello@heyimcat.com).
 
-##Contributors
+## Contributors
 Toothpaste definitely could not have grown the way it continues to without the contributors helping. I couldn't do it alone. A big thank you to:
 
 - Timothy ([@codetheory](http://twitter.com/@codetheory)) for recreating Toothpaste for Atom
 - Adam Swinden ([@AdamSwinden](https://twitter.com/adamswinden)) for recreating Toothpaste for Xcode
-- Michiel Renty ([@mrenty](https://twitter.com/mrenty)) for creating Toothpaste for WebStorm
+- Michiel Renty ([@mrenty](https://twitter.com/mrenty)) for recreating Toothpaste for WebStorm


### PR DESCRIPTION
@imcatnoone Here's the atom install instructions. I've also been a little bit cheeky and updated the README to be a bit more readable from most markdown editors and fixed a few things here and there.

I suggest we post an issue for help writing instructions for installing these themes manually on Windows though. That might hold off a lot of issues that could come in.
