### PR TITLE
Fix username links in Contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Toothpaste definitely could not have grown the way it continues to without the c
 - Adam Swinden ([@AdamSwinden](https://twitter.com/adamswinden)) for recreating Toothpaste for Xcode
 - Michiel Renty ([@mrenty](https://twitter.com/mrenty)) for recreating Toothpaste for WebStorm
 - Benedikt Lehnert ([@blehnert](https://twitter.com/blehnert)) for whipping up the Toothpaste landing page
-- Josh Auget ([@jfonte])(https://twitter.com/thisismyclone) for the manual instructions for ST2 on Windows
-- Lachlan Campbell ([@lachlanjc])(https://twitter.com/lachlanjc) for installation instructions with `apm` from Command Line 
+- Josh Auget ([@jfonte](https://twitter.com/thisismyclone)) for the manual instructions for ST2 on Windows
+- Lachlan Campbell ([@lachlanjc](https://twitter.com/lachlanjc)) for installation instructions with `apm` from Command Line 
 
 ## Creating Issues
 Run into a dilemma and want to create an issue for it? Go ahead and do so! But first:


### PR DESCRIPTION
Right now in the Contributors section of the README, the parentheses for the last two usernames are in the wrong place, making the links show. Nitpicking :wink: 

Now:
<img width="888" alt="screenshot 2016-02-08 13 59 54" src="https://cloud.githubusercontent.com/assets/5074763/12895815/6a17a700-ce6c-11e5-93cf-34f7d7f3ff8b.png">

Fixed:
<img width="702" alt="screenshot 2016-02-08 14 01 38" src="https://cloud.githubusercontent.com/assets/5074763/12895831/7f3e2212-ce6c-11e5-8e50-5a513eee23d9.png">
